### PR TITLE
refact: Simplify plugin inititalization

### DIFF
--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -101,16 +101,9 @@ add_action(
 		}
 
 		require_once $my_autoload;
-	},
-	20
-);
 
-add_action(
-	'wp_loaded',
-	function () {
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
-
-		( new \WordPress\AI_Client\API_Credentials\API_Credentials_Manager() )->initialize();
-	}
+	},
+	20
 );


### PR DESCRIPTION
Thanks to the fix in php-ai-client (https://github.com/WordPress/wp-ai-client/issues/41#issuecomment-3722006078) calling `API_Credentials_Manager→initialize()` isn’t necessary anymore.