### PR TITLE
feat: wordpress 7 compatibility

### DIFF
--- a/includes/MittwaldAIProvider.php
+++ b/includes/MittwaldAIProvider.php
@@ -60,13 +60,16 @@ class MittwaldAIProvider extends AbstractApiProvider {
 	protected static function createProviderMetadata(): ProviderMetadata {
 		$langUrlPart = str_starts_with( get_user_locale(), 'de' ) ? 'de/' : '';
 
+		/*
+		TODO: Add a proper description, as soon as we can safely depend on wordpress/php-ai-client ^1.2:
+		__( 'Use german-hosted and GDPR-compliant open-weight models hosted by mittwald', 'mittwald-ai-provider' )
+		*/
+
 		return new ProviderMetadata(
 			'mittwald',
 			'mittwald',
 			ProviderTypeEnum::cloud(),
 			'https://developer.mittwald.de/' . $langUrlPart . 'docs/v2/platform/aihosting/access-and-usage/access/',
-			null,
-			__( 'Use german-hosted and GDPR-compliant open-weight models hosted by mittwald', 'mittwald-ai-provider' )
 		);
 	}
 

--- a/includes/MittwaldAIProvider.php
+++ b/includes/MittwaldAIProvider.php
@@ -65,6 +65,8 @@ class MittwaldAIProvider extends AbstractApiProvider {
 			'mittwald',
 			ProviderTypeEnum::cloud(),
 			'https://developer.mittwald.de/' . $langUrlPart . 'docs/v2/platform/aihosting/access-and-usage/access/',
+			null,
+			__( 'Use german-hosted and GDPR-compliant open-weight models hosted by mittwald', 'mittwald-ai-provider' )
 		);
 	}
 

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -7,7 +7,6 @@
  * Author: mittwald, Lukas Fritze, Martin Helmich
  * Author URI: https://www.mittwald.de/
  * License: GPL-2.0-or-later
- * Requires Plugins: ai
  */
 
 namespace Mittwald\AiProvider;

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -101,9 +101,16 @@ add_action(
 		}
 
 		require_once $my_autoload;
-
-		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
 	},
 	20
+);
+
+add_action(
+	'wp_loaded',
+	function () {
+		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
+
+		( new \WordPress\AI_Client\API_Credentials\API_Credentials_Manager() )->initialize();
+	}
 );

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: mittwald AI provider
+ * Plugin Name: AI Provider for mittwald
  * Plugin URI: https://github.com/mittwald/wordpress-ai-provider
  * Description: Adds mittwald AI hosting to the available AI providers
  * Version: trunk
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function display_missing_ai_plugin_notice(): void {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The mittwald AI provider plugin requires the WordPress AI Client plugin to be installed and activated.', 'mittwald-ai-provider' ); ?></p>
+		<p><?php esc_html_e( 'The AI Provider for mittwald plugin requires either at least WordPress 7.0, or the AI Experiments plugin to be installed and activated.', 'mittwald-ai-provider' ); ?></p>
 	</div>
 	<?php
 }

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -47,8 +47,9 @@ function display_composer_notice(): void {
 			<?php
 			printf(
 			/* translators: %s: composer install command */
-				esc_html__( 'Your installation of the mittwald AI provider plugin is incomplete. Please run %s.', 'mittwald-ai-provider' ),
-				'<code>composer install</code>'
+				esc_html__( 'Your installation of the mittwald AI provider plugin is incomplete. Please run %1$s in the %2$s directory.', 'mittwald-ai-provider' ),
+				'<code>composer install --no-dev</code>',
+				'<code>' . esc_html( plugin_dir_path( __FILE__ ) ) . '</code>'
 			);
 			?>
 		</p>

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -46,7 +46,7 @@ function display_composer_notice(): void {
 		<p>
 			<?php
 			printf(
-			/* translators: %s: composer install command */
+				/* translators: %1$s: composer install command, %2$s: plugin directory path */
 				esc_html__( 'Your installation of the mittwald AI provider plugin is incomplete. Please run %1$s in the %2$s directory.', 'mittwald-ai-provider' ),
 				'<code>composer install --no-dev</code>',
 				'<code>' . esc_html( plugin_dir_path( __FILE__ ) ) . '</code>'

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -87,7 +87,7 @@ if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
 }
 
 add_action(
-	'plugins_loaded',
+	'init',
 	function () {
 		// This plugin requires the WordPress AI client; in WordPress 6.9, this requires the
 		// "AI Experiments" plugin, while in WordPress 7.0+, the AI client is part of core.

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -116,7 +116,9 @@ add_action(
 		require_once $my_autoload;
 
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
+		if ( ! $registry->hasProvider( MittwaldAIProvider::class ) ) {
+			$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
+		}
 	},
 	20
 );

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -62,23 +62,29 @@ function display_composer_notice(): void {
  *
  * NOTE: This plugin does not actually have its own settings page; instead,
  * we piggyback on the settings page of the main `ai` plugin.
+ *
+ * NOTE: This is only necessary for WordPress 6.9; in WordPress 7, AI
+ * providers will be discovered automatically, without having to inject
+ * themselves into the settings page.
  */
-add_filter(
-	'plugin_action_links_' . plugin_basename( __FILE__ ),
-	function ( array $links ): array {
-		$settings_link = sprintf(
-			'<a href="%1$s">%2$s</a>',
-			admin_url( 'options-general.php?page=wp-ai-client' ),
-			// use translation from required plugin `ai`.
-			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-			esc_html__( 'Settings', 'ai' )
-		);
+if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
+	add_filter(
+		'plugin_action_links_' . plugin_basename( __FILE__ ),
+		function ( array $links ): array {
+			$settings_link = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				admin_url( 'options-general.php?page=wp-ai-client' ),
+				// use translation from required plugin `ai`.
+                    // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+					esc_html__( 'Settings', 'ai' )
+			);
 
-		array_unshift( $links, $settings_link );
+			array_unshift( $links, $settings_link );
 
-		return $links;
-	}
-);
+			return $links;
+		}
+	);
+}
 
 add_action(
 	'plugins_loaded',

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -89,17 +89,24 @@ if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
 add_action(
 	'plugins_loaded',
 	function () {
-		// Note: We assume that the Composer autoloader of the "ai" plugin is already loaded,
-		// because that plugin does so in the `plugins_loaded` action with default priority (10).
-		// We use priority 20 to ensure our code runs *after* that.
+		// This plugin requires the WordPress AI client; in WordPress 6.9, this requires the
+		// "AI Experiments" plugin, while in WordPress 7.0+, the AI client is part of core.
 		//
-		// For this reason, there is no realistic way for this check to fail; this is just us
-		// being defensive.
+		// For the latter reason, we cannot simply use a plugin dependency to require the
+		// "AI Experiments" plugin, since that would prevent the mittwald AI provider from
+		// being used on WordPress 7.0+. Therefore, we check for the existence of the main
+		// class of the AI client plugin, and if it's not present, we display an admin notice
+		// about the missing dependency.
 		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
 			add_action( 'admin_notices', __NAMESPACE__ . '\\display_missing_ai_plugin_notice' );
 			return;
 		}
 
+		// vendor/autoload.php *should* always be present, since we ship the plugin with its
+		// dependencies installed. However, in development setups (e.g. when cloning the plugin
+		// from GitHub), it's possible for the plugin to be missing its dependencies if
+		// `composer install` hasn't been run. In that case, we display an admin notice about
+		// the missing dependencies.
 		$my_autoload = __DIR__ . '/vendor/autoload.php';
 		if ( ! file_exists( $my_autoload ) ) {
 			add_action( 'admin_notices', __NAMESPACE__ . '\\display_composer_notice' );

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -62,29 +62,23 @@ function display_composer_notice(): void {
  *
  * NOTE: This plugin does not actually have its own settings page; instead,
  * we piggyback on the settings page of the main `ai` plugin.
- *
- * NOTE: This is only necessary for WordPress 6.9; in WordPress 7, AI
- * providers will be discovered automatically, without having to inject
- * themselves into the settings page.
  */
-if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
-	add_filter(
-		'plugin_action_links_' . plugin_basename( __FILE__ ),
-		function ( array $links ): array {
-			$settings_link = sprintf(
-				'<a href="%1$s">%2$s</a>',
-				admin_url( 'options-general.php?page=wp-ai-client' ),
-				// use translation from required plugin `ai`.
-                    // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-					esc_html__( 'Settings', 'ai' )
-			);
+add_filter(
+	'plugin_action_links_' . plugin_basename( __FILE__ ),
+	function ( array $links ): array {
+		$settings_link = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			admin_url( 'options-general.php?page=wp-ai-client' ),
+			// use translation from required plugin `ai`.
+			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+			esc_html__( 'Settings', 'ai' )
+		);
 
-			array_unshift( $links, $settings_link );
+		array_unshift( $links, $settings_link );
 
-			return $links;
-		}
-	);
-}
+		return $links;
+	}
+);
 
 add_action(
 	'init',

--- a/readme.txt
+++ b/readme.txt
@@ -1,18 +1,20 @@
-=== mittwald AI provider ===
+=== AI Provider for mittwald ===
 Contributors: mittwald, lukasfritzedev, mhelmich
 Tags: AI, llm
 Requires at least: 6.9
-Tested up to: 6.9
+Tested up to: 7.0-beta2
 Stable tag: trunk
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Connects WordPress AI Experiments to mittwald AI Hosting, enabling AI-powered features via an OpenAI-compatible provider integration.
+Connects WordPress AI to mittwald AI Hosting, enabling AI-powered features via an OpenAI-compatible provider integration.
 
 == Description ==
 
-This plugin integrates [mittwald AI Hosting](https://developer.mittwald.de/docs/v2/platform/aihosting/) with the [WordPress AI Experiments Plugin](https://wordpress.org/plugins/ai/), enabling AI-powered features on your WordPress site using mittwald's infrastructure.
+This plugin integrates [mittwald AI Hosting](https://developer.mittwald.de/docs/v2/platform/aihosting/) with WordPress AI features, enabling AI-powered features on your WordPress site using mittwald's infrastructure.
+
+On WordPress 6.9, you need to enable the [WordPress AI Experiments Plugin](https://wordpress.org/plugins/ai/) to use this plugin. Starting with WordPress 7.0, this plugin will work without the AI Experiments plugin, as the necessary features will be included in core.
 
 == Supported Operations & Models ==
 
@@ -34,7 +36,7 @@ Fully supported for conversational AI, content generation, and chat-based intera
 
 == Installation ==
 
-Make sure the Plugin [AI Experiments](https://wordpress.org/plugins/ai/) is installed. If not, install and activate it.
+If you are using WordPress 6.9, make sure the Plugin [AI Experiments](https://wordpress.org/plugins/ai/) is installed. If it is not installed, install and activate it. On WordPress 7.0 and later, the necessary features are included in core, so you can skip this step.
 
 Install this plugin:
 


### PR DESCRIPTION
- **chore(!!!): drop hard dependency on "ai" plugin**
- **ux: clarify "composer install" hint better**
- **ux: add a description to provider metadata**
- **chore: synchronize plugin name with "AI Provider for <xyz>" pattern**
- **fix: do not link to settings page in WP7**
- **docs: explain setup logic better in init hook**
- **chore: move provider registration to "init" hook**
- **fix: prevent duplicate provider registration.**
- **docs: add translator notice to new composer notice**
