### PR TITLE
Revert "refact: Simplify plugin inititalization"

### DIFF
--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -101,9 +101,16 @@ add_action(
 		}
 
 		require_once $my_autoload;
-
-		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
-		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
 	},
 	20
+);
+
+add_action(
+	'wp_loaded',
+	function () {
+		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+		$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
+
+		( new \WordPress\AI_Client\API_Credentials\API_Credentials_Manager() )->initialize();
+	}
 );


### PR DESCRIPTION
This reverts commit a1d091929d36228a2e7d17cac25190d181f46426.

Fixes the following error on the AI experiments settings page:

> Fatal error: Uncaught Http\Discovery\Exception\DiscoveryFailedException: Could not find resource using any discovery strategy.
