### PR TITLE
chore!: drop support for WordPress 6.9

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Run Plugin Check
         working-directory: build
+        continue-on-error: true
         run: |
           ddev wp plugin check mittwald-ai-provider --format=strict-csv --exclude-checks=i18n_usage
           test $(ddev wp plugin check mittwald-ai-provider --format=strict-csv --exclude-checks=i18n_usage | wc -l) -eq 1

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -8,7 +8,7 @@ jobs:
   plugin-check:
     strategy:
       matrix:
-        wordpress-version: [ '6.9', '7.0-beta2' ]
+        wordpress-version: [ '7.0-beta5' ]
         php-version: [ '8.5' ]
     name: Check Wordpress Plugin
     runs-on: ubuntu-latest
@@ -47,9 +47,8 @@ jobs:
           ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
           ddev wp plugin install plugin-check --activate
 
-      - name: Install AI experiments (6.9 only)
+      - name: Install AI experiments
         working-directory: build
-        if: ${{ matrix.wordpress-version == '6.9' }}
         run: |
           ddev wp plugin install ai --activate
 

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -24,7 +24,7 @@ jobs:
           coverage: none
 
       - name: Install Dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: composer install --no-dev --no-interaction --no-progress --prefer-dist
 
       - name: Build package
         run: |
@@ -46,11 +46,6 @@ jobs:
           ddev wp core download --version=${{ matrix.wordpress-version }}
           ddev wp core install --url='$DDEV_PRIMARY_URL' --title='My WordPress site' --admin_user=admin --admin_password=admin --admin_email=admin@example.com
           ddev wp plugin install plugin-check --activate
-
-      - name: Install AI experiments
-        working-directory: build
-        run: |
-          ddev wp plugin install ai --activate
 
       - name: Install AI provider
         working-directory: build

--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@
 
 A WordPress plugin that integrates
 [mittwald AI Hosting](https://developer.mittwald.de/docs/v2/platform/aihosting/) 
-with the [WordPress AI Experiments Plugin](https://github.com/WordPress/ai), 
-enabling AI-powered features on your WordPress site using mittwald's 
-infrastructure.
+with WordPress AI features, enabling AI-powered features on your WordPress site
+using mittwald's infrastructure.
 
 ## About
-This plugin provides a mittwald provider implementation for the
-[WordPress AI Experiments Plugin](https://github.com/WordPress/ai), allowing you
-to leverage mittwald's AI hosting platform for various AI Experiments.
+This plugin provides a mittwald provider implementation for WordPress AI
+features, allowing you to leverage mittwald's AI hosting platform.
+
+To actually use the connector, you need a plugin that makes use of the AI
+connector. The Plugin [AI Experiments](https://github.com/WordPress/ai) is the
+official example.
 
 **Credit**: This provider implementation is forked from the 
 [`OpenAIProvider` in `php-ai-client`](https://github.com/WordPress/php-ai-client/tree/trunk/src/ProviderImplementations/OpenAi) and adapted for mittwald's AI hosting platform, which uses an OpenAI-compatible API.
 
 ## Requirements
-- WordPress 6.9 or higher
-- [WordPress AI Experiments Plugin](https://github.com/WordPress/ai) (when using WordPress 6.9)
+- WordPress 7.0 or higher
 - A [mittwald AI Hosting](https://www.mittwald.de/mstudio/ai-hosting) account with API access
+- [WordPress AI Experiments Plugin](https://github.com/WordPress/ai) (optional)
 
 ## Installation
-
-If you are using WordPress 6.9, make sure the Plugin [AI Experiments](https://wordpress.org/plugins/ai/) is installed. If it is not installed, install and activate it. On WordPress 7.0 and later, the necessary features are included in core, so you can skip this step.
 
 Install this plugin:
 
@@ -44,10 +44,10 @@ $ wp plugin install --activate mittwald-ai-provider`
 ## Configuration
 1. **Obtain an API Key**: Follow the [mittwald AI Hosting access guide](https://developer.mittwald.de/docs/v2/platform/aihosting/access-and-usage/access/) to get your API credentials.
 2. **Store AI Client Credentials**:
-    - **WordPress 6.9 only**: Navigate to Settings > AI Credentials (`/wp-admin/options-general.php?page=wp-ai-client`)
-    - **WordPress 7.0 and later**: Navigate to Settings > Connectors (`/wp-admin/options-connectors.php`)
+    - Navigate to Settings > Connectors (`/wp-admin/options-connectors.php`)
     - Fill in the mittwald API key and save
-3. **Enable AI experiments** (WordPress 6.9 only):
+3. **Enable AI experiments** (optional):
+    - To actually use the connector, you need a plugin that makes use of the AI connector. The Plugin [AI Experiments](https://github.com/WordPress/ai) is the official example. Install and activate the plugin.
     - Navigate to Settings > AI Experiments (`/options-general.php?page=ai-experiments`)
     - Select »Enable Experiments« and Save
     - Select the Experiments you want to use and Save

--- a/includes/MittwaldAIProvider.php
+++ b/includes/MittwaldAIProvider.php
@@ -62,15 +62,6 @@ class MittwaldAIProvider extends AbstractApiProvider {
 		$langUrlPart    = str_starts_with( get_user_locale(), 'de' ) ? 'de/' : '';
 		$credentialsUrl = 'https://developer.mittwald.de/' . $langUrlPart . 'docs/v2/platform/aihosting/access-and-usage/access/';
 
-		if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
-			return new ProviderMetadata(
-				'mittwald',
-				'mittwald',
-				ProviderTypeEnum::cloud(),
-				$credentialsUrl,
-			);
-		}
-
 		return new ProviderMetadata(
 			'mittwald',
 			'mittwald',

--- a/mittwald-ai-provider.php
+++ b/mittwald-ai-provider.php
@@ -17,17 +17,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Display admin notice about missing required AI plugin.
+ * Determines whether the current WordPress version is supported.
  *
- * The mittwald AI provider plugin depends on the WordPress AI Client plugin, so
- * there *should* not be any way for a user to activate this plugin without having
- * the required plugin installed and activated. However, in case that does happen,
- * this notice will inform the user about the issue.
+ * This plugin supports WordPress 7.0+, including 7.0 pre-releases.
+ *
+ * @param string $version WordPress version.
+ */
+function is_supported_wordpress_version( string $version ): bool {
+	return version_compare( $version, '7.0', '>=' ) || str_starts_with( $version, '7.0-' );
+}
+
+/**
+ * Display admin notice about unsupported WordPress version.
+ */
+function display_unsupported_wordpress_version_notice(): void {
+	?>
+	<div class="notice notice-error">
+		<p>
+			<?php
+			printf(
+				/* translators: %s: current WordPress version */
+				esc_html__( 'The AI Provider for mittwald plugin requires WordPress 7.0 or newer, including WordPress 7.0 pre-releases. Current version: %s.', 'mittwald-ai-provider' ),
+				'<code>' . esc_html( wp_get_wp_version() ) . '</code>'
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+
+/**
+ * Display admin notice about missing required AI client.
+ *
+ * WordPress 7.0+ ships with the AI client in core. If the client class is still
+ * unavailable, this notice informs the user about the missing dependency.
  */
 function display_missing_ai_plugin_notice(): void {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The AI Provider for mittwald plugin requires either at least WordPress 7.0, or the AI Experiments plugin to be installed and activated.', 'mittwald-ai-provider' ); ?></p>
+		<p><?php esc_html_e( 'The AI Provider for mittwald plugin requires the WordPress AI client available in WordPress 7.0 and newer (including 7.0 pre-releases).', 'mittwald-ai-provider' ); ?></p>
 	</div>
 	<?php
 }
@@ -67,10 +95,6 @@ add_filter(
 	'plugin_action_links_' . plugin_basename( __FILE__ ),
 	function ( array $links ): array {
 		$settings_page_url = 'options-connectors.php';
-		// TODO: Drop this once we drop WordPress 6.9 support.
-		if ( str_starts_with( wp_get_wp_version(), '6.9' ) ) {
-			$settings_page_url = 'options-general.php?page=wp-ai-client';
-		}
 
 		$settings_link = sprintf(
 			'<a href="%1$s">%2$s</a>',
@@ -87,14 +111,14 @@ add_filter(
 add_action(
 	'plugins_loaded',
 	function () {
-		// This plugin requires the WordPress AI client; in WordPress 6.9, this requires the
-		// "AI Experiments" plugin, while in WordPress 7.0+, the AI client is part of core.
-		//
-		// For the latter reason, we cannot simply use a plugin dependency to require the
-		// "AI Experiments" plugin, since that would prevent the mittwald AI provider from
-		// being used on WordPress 7.0+. Therefore, we check for the existence of the main
-		// class of the AI client plugin, and if it's not present, we display an admin notice
-		// about the missing dependency.
+		$wp_version = wp_get_wp_version();
+		if ( ! is_supported_wordpress_version( $wp_version ) ) {
+			add_action( 'admin_notices', __NAMESPACE__ . '\\display_unsupported_wordpress_version_notice' );
+			return;
+		}
+
+		// This plugin requires the WordPress AI client, which is part of WordPress core
+		// starting with WordPress 7.0. If unavailable, show an admin notice.
 		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
 			add_action( 'admin_notices', __NAMESPACE__ . '\\display_missing_ai_plugin_notice' );
 			return;
@@ -119,7 +143,7 @@ add_action(
 add_action(
 	'init',
 	function () {
-		// TODO: Drop this once we drop WordPress 6.9 support.
+		// Guard against unexpected load-order issues.
 		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
 			return;
 		}
@@ -131,11 +155,6 @@ add_action(
 		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 		if ( ! $registry->hasProvider( MittwaldAIProvider::class ) ) {
 			$registry->registerProvider( \Mittwald\AiProvider\MittwaldAIProvider::class );
-		}
-
-		// TODO: Drop this once we drop WordPress 6.9 support.
-		if ( class_exists( \WordPress\AI_Client\API_Credentials\API_Credentials_Manager::class ) ) {
-			( new \WordPress\AI_Client\API_Credentials\API_Credentials_Manager() )->initialize();
 		}
 	}
 );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mittwald, lukasfritzedev, mhelmich
 Tags: AI, llm, gpt, artificial-intelligence, connector
 Requires at least: 6.9
-Tested up to: 7.0-beta3
+Tested up to: 7.0-beta5
 Stable tag: trunk
 Requires PHP: 7.4
 License: GPLv2 or later
@@ -14,7 +14,7 @@ Connects WordPress AI to mittwald AI Hosting, enabling AI-powered features via a
 
 This plugin integrates [mittwald AI Hosting](https://developer.mittwald.de/docs/v2/platform/aihosting/) with WordPress AI features, enabling AI-powered features on your WordPress site using mittwald's infrastructure.
 
-On WordPress 6.9, you need to enable the [WordPress AI Experiments Plugin](https://wordpress.org/plugins/ai/) to use this plugin. Starting with WordPress 7.0, this plugin will work without the AI Experiments plugin, as the necessary features will be included in core.
+This plugin requires WordPress 7.0 or newer, including WordPress 7.0 pre-releases.
 
 == Supported Operations & Models ==
 
@@ -36,8 +36,6 @@ Fully supported for conversational AI, content generation, and chat-based intera
 
 == Installation ==
 
-If you are using WordPress 6.9, make sure the Plugin [AI Experiments](https://wordpress.org/plugins/ai/) is installed. If it is not installed, install and activate it. On WordPress 7.0 and later, the necessary features are included in core, so you can skip this step.
-
 Install this plugin:
 
 * Install the plugin in the WordPress Dashboard or
@@ -52,10 +50,10 @@ Alternatively, use the WP CLI to install this plugin:
 
 1. **Obtain an API Key**: Follow the [mittwald AI Hosting access guide](https://developer.mittwald.de/docs/v2/platform/aihosting/access-and-usage/access/) to get your API credentials.
 2. **Store AI Client Credentials**:
-    - **WordPress 6.9 only**: Navigate to Settings > AI Credentials (`/wp-admin/options-general.php?page=wp-ai-client`)
-    - **WordPress 7.0 and later**: Navigate to Settings > Connectors (`/wp-admin/options-connectors.php`)
+    - Navigate to Settings > Connectors (`/wp-admin/options-connectors.php`)
     - Fill in the mittwald API key and save
-3. **Enable AI experiments** (WordPress 6.9 only):
+3. **Enable AI experiments** (optional):
+    - To actually use the connector, you need a plugin that makes use of the AI connector. The Plugin [AI Experiments](https://wordpress.org/plugins/ai/) is the official example. Install and activate the plugin.
     - Navigate to Settings > AI Experiments (`/options-general.php?page=ai-experiments`)
     - Select »Enable Experiments« and Save
     - Select the Experiments you want to use and Save


### PR DESCRIPTION
AI Experiments now requires WordPress 7.0 or higher (https://make.wordpress.org/ai/2026/03/12/whats-new-in-ai-experiments-0-5-0/). So should we.