### PR TITLE
fix: Fix outputSchema on application/json requests

### DIFF
--- a/includes/MittwaldTextGenerationModel.php
+++ b/includes/MittwaldTextGenerationModel.php
@@ -28,4 +28,23 @@ class MittwaldTextGenerationModel extends AbstractOpenAiCompatibleTextGeneration
 			$this->getRequestOptions()
 		);
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since 0.1.0
+	 */
+	protected function prepareResponseFormatParam( ?array $outputSchema ): array {
+		if ( is_array( $outputSchema ) ) {
+			return array(
+				'type'        => 'json_schema',
+				'json_schema' => array(
+					'name'   => 'outputSchema',
+					'schema' => $outputSchema,
+				),
+			);
+		}
+
+		return array( 'type' => 'json_object' );
+	}
 }


### PR DESCRIPTION
Without this fix, the experiment "Review notes" produces an error "Bad Request (400) - Got bad request: Failed to validate 6 parameters". This is because the request with made with output MIME type `application/json`, but the provided outputSchema does not match the schema format needed by our LLM-Backend.

Before:
```json
{
  ...
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "type": "object",
      "properties": { ... },
      "required": [ ... ],
      "additionalProperties": false
    }
  }
}
```

After:
```json
{
  ...
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "outputSchema",
      "schema": {
        "type": "object",
        "properties": { ... },
        "required": [ ... ],
        "additionalProperties": false
      }
    }
  }
}
```